### PR TITLE
Update moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7707,9 +7707,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "dependencies": {
     "jest-cli": "22.4.3",
-    "moment": "2.22.1"
+    "moment": "^2.24.0"
   },
   "devDependencies": {
     "@types/jest": "20.0.2",


### PR DESCRIPTION
Update momentjs.
With dayspan depending on a fixed moment version, we were both including 2.22.1 and 2.24.0 in our webpack build.