### PR TITLE
Fix performance issues in Calendar.eventsForDay(...) implementation

### DIFF
--- a/src/Schedule.ts
+++ b/src/Schedule.ts
@@ -723,6 +723,11 @@ export class Schedule<M>
    */
   public isFullyExcluded(day: Day): boolean
   {
+    // If exclude object is empty, bail early.
+    if (this.exclude.isEmpty()) {
+      return false
+    }
+
     if (this.isExcluded(day, false))
     {
       return true;
@@ -942,8 +947,12 @@ export class Schedule<M>
             }
           }
 
-          current = current.prev();
           lookBehind--;
+          // Generating current.prev() is costly.
+          // Avoid generating it if looping condition is no longer satisfied.
+          if (lookBehind >= 0) {
+            current = current.prev()
+          }
         }
       }
     });


### PR DESCRIPTION
When there are a lot of events in a calendar month, `Calendar.eventsForDay(...)` is quite inefficient.
Upon profiling, we noticed that two `Schedule` methods used in by above method is doing unnecessary mutations on `Day` objects.

This PR proposes following changes to `Schedule.isFullyExcluded(day: Day)` and `Schedule.iterateSpans(day: Day, covers: boolean = false)`.

1. `isFullyExcluded` unnecessarily created a mutated version of given day object, even though there are no exclusions defined for the schedule. Add an early return in this case.
2. `iterateSpans` generates a day using `prev()` in the inner loop. Skip this if this is the last iterator.